### PR TITLE
Support use case to share the same state backend for multiple environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Create an S3 bucket to store the Terraform state file and a DynamoDB table (can 
 The bucket has an policy where you can only upload files with encryption enabled.
 
 ### Available variables:
- * [`environment`]: String(required): the name of the environment this state belongs to (prod,stag,dev)
- * [`project`]: String(required): the name of the project this state belongs to
+ * [`environment`]: String(optional): the name of the environment this state belongs to (prod,stag,dev). If omitted, all the resource names won't contain any environment information.
+ * [`project`]: String(required): the name of the project this state belongs to.
  * [`create_dynamodb_lock_table`]: String(optional): toggle to enable or not the DynamoDB table creation. Set to false to disable. Defaults to true.
+ * [`create_s3_bucket`]: String(optional): toggle to enable or not the S3 bucket creation. Set to false to disable. Defaults to true.
+ * [`shared_aws_account_ids`]: List(optional): A list of AWS account IDs to share the S3 bucket and DynamoDB table with. Defaults to [].
 
 ### Output:
  * [`bucket_id`]: String: The name of the bucket
@@ -17,8 +19,12 @@ The bucket has an policy where you can only upload files with encryption enabled
 ### Example
 ```
 module "s3" {
-  source = "github.com/skyscrapers/terraform-state//s3?ref=<git_hash>"
+  source      = "github.com/skyscrapers/terraform-state//s3?ref=1.0.0"
   environment = "test"
-  project = "some-project"
+  project     = "some-project"
 }
 ```
+
+## TODO
+
+Document multi-environment setup use-case.

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "state" {
   count  = "${var.create_s3_bucket == "true" ? 1 : 0}"
-  bucket = "terraform-state-${var.project}-${var.environment}"
+  bucket = "terraform-state-${var.project}${data.template_file.environment_suffix.rendered}"
   acl    = "private"
 
   versioning {
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "state" {
   }
 
   tags {
-    Name        = "terraform-state-${var.project}-${var.environment}"
+    Name        = "terraform-state-${var.project}${data.template_file.environment_suffix.rendered}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }
@@ -85,7 +85,7 @@ EOF
 
 resource "aws_dynamodb_table" "terraform-state-locktable" {
   count          = "${var.create_dynamodb_lock_table == "true" ? 1 : 0}"
-  name           = "terraform-state-lock-${var.project}-${var.environment}"
+  name           = "terraform-state-lock-${var.project}${data.template_file.environment_suffix.rendered}"
   read_capacity  = 1
   write_capacity = 1
   hash_key       = "LockID"
@@ -96,8 +96,16 @@ resource "aws_dynamodb_table" "terraform-state-locktable" {
   }
 
   tags {
-    Name        = "terraform-state-lock-${var.project}-${var.environment}"
+    Name        = "terraform-state-lock-${var.project}${data.template_file.environment_suffix.rendered}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
+  }
+}
+
+data "template_file" "environment_suffix" {
+  template = "$${suffix}"
+
+  vars {
+    suffix = "${length(var.environment) > 0 ? format("-%s", var.environment) : ""}"
   }
 }

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,4 +1,5 @@
 resource "aws_s3_bucket" "state" {
+  count  = "${var.create_s3_bucket == "true" ? 1 : 0}"
   bucket = "terraform-state-${var.project}-${var.environment}"
   acl    = "private"
 
@@ -14,8 +15,8 @@ resource "aws_s3_bucket" "state" {
 }
 
 resource "aws_s3_bucket_policy" "b" {
+  count  = "${var.create_s3_bucket == "true" ? 1 : 0}"
   bucket = "${aws_s3_bucket.state.bucket}"
-
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -51,9 +52,8 @@ EOF
 }
 
 resource "aws_s3_bucket_policy" "cross_account_bucket_sharing" {
-  count  = "${length(var.shared_aws_account_ids) > 0 ? 1 : 0}"
+  count  = "${length(var.shared_aws_account_ids) > 0 && var.create_s3_bucket == "true" ? 1 : 0}"
   bucket = "${aws_s3_bucket.state.bucket}"
-
   policy = <<EOF
 {
    "Version": "2012-10-17",

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -4,6 +4,7 @@ variable "project" {
 
 variable "environment" {
   description = "Environment name"
+  default     = ""
 }
 
 variable "create_dynamodb_lock_table" {

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -7,7 +7,12 @@ variable "environment" {
 }
 
 variable "create_dynamodb_lock_table" {
-  description = "Also create a DynamoDB table for state locking. Set to false or 0 to disable. Defaults to true"
+  description = "Create a DynamoDB table for state locking. Set to false or 0 to disable. Defaults to true"
+  default     = "true"
+}
+
+variable "create_s3_bucket" {
+  description = "Create the S3 bucket and policy. Set to false of 0 to disable. Defaults to true"
   default     = "true"
 }
 

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -10,3 +10,9 @@ variable "create_dynamodb_lock_table" {
   description = "Also create a DynamoDB table for state locking. Set to false or 0 to disable. Defaults to true"
   default     = "true"
 }
+
+variable "shared_aws_account_ids" {
+  description = "A list of AWS account IDs to share the S3 bucket and DynamoDB table with."
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
With the new terraform environments, we'll use the same S3 backend configuration for all the environments. In such case we need to share the S3 bucket among all the AWS accounts (in the case we there's a different account per each environment). The following changes are made for that purpose:

- Added the proper permissions to share a bucket in the bucket policy (optional)
- Removed the environment suffix from the bucket and DynamoDB table names (optional)
- And finally, the DynamoDB lock table cannot be shared in the same way as an S3 bucket, so it must be created on each environment. That's why I've made it possible to only create the DynamoDB table without the S3 bucket.