### PR TITLE
Explicitly force to string type to workaround bug in 0.9.5

### DIFF
--- a/s3/main.tf
+++ b/s3/main.tf
@@ -45,7 +45,7 @@ resource "aws_s3_bucket_policy" "b" {
           "s3:x-amz-server-side-encryption": "true"
         }
       }
-    }${length(data.template_file.cross_account_bucket_sharing_policy.*.rendered) == 0 ? "" : join("", data.template_file.cross_account_bucket_sharing_policy.*.rendered)}
+    }${length(data.template_file.cross_account_bucket_sharing_policy.*.rendered) == 0 ? format("%s","") : format("%s", join("", data.template_file.cross_account_bucket_sharing_policy.*.rendered))}
   ]
 }
 EOF


### PR DESCRIPTION
Workaround for a bug in TF 0.9.5 (https://github.com/hashicorp/terraform/issues/14399), otherwise we get the following error:

```
1 error(s) occurred:

* module.terraform-state-ocs.aws_s3_bucket_policy.b: 1 error(s) occurred:

* module.terraform-state-ocs.aws_s3_bucket_policy.b: At column 8, line 28: true and false expression types must match; have type string and type unknown in:

{
  "Version": "2012-10-17",
  "Id": "PutObjPolicy",
  "Statement": [
    {
      "Sid": "DenyIncorrectEncryptionHeader",
      "Effect": "Deny",
      "Principal": "*",
      "Action": "s3:PutObject",
      "Resource": "${aws_s3_bucket.state.arn}/*",
      "Condition": {
        "StringNotEquals": {
          "s3:x-amz-server-side-encryption": "AES256"
        }
      }
    },
    {
      "Sid": "DenyUnEncryptedObjectUploads",
      "Effect": "Deny",
      "Principal": "*",
      "Action": "s3:PutObject",
      "Resource": "${aws_s3_bucket.state.arn}/*",
      "Condition": {
        "Null": {
          "s3:x-amz-server-side-encryption": "true"
        }
      }
    }${length(data.template_file.cross_account_bucket_sharing_policy.*.rendered) == 0 ? "" : join("", data.template_file.cross_account_bucket_sharing_policy.*.rendered)}
  ]
}
```

This should be fixed again in TF 0.9.6