### PR TITLE
Fix output of s3 module for when we don't create an S3 bucket or dynamo

### DIFF
--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -1,7 +1,7 @@
 output "bucket_id" {
-  value = "${aws_s3_bucket.state.id}"
+  value = "${join("", aws_s3_bucket.state.*.id)}"
 }
 
 output "locktable_id" {
-  value = "${aws_dynamodb_table.terraform-state-locktable.id}"
+  value = "${join("", aws_dynamodb_table.terraform-state-locktable.*.id)}"
 }


### PR DESCRIPTION
Terraform 0.11 is now more strict with outputs, so if a resource doesn't exist, instead of leaving the output empty, it fails. This is a workaround to avoid that.