### PR TITLE
Refactor to reflect latest changes in state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
 # terraform-state
+
 Everything for state related terraform
 
 ## s3
+
 Create an S3 bucket to store the Terraform state file and a DynamoDB table (can be disabled) to support state locking.
 The bucket has an policy where you can only upload files with encryption enabled.
 
-### Available variables:
- * [`environment`]: String(optional): the name of the environment this state belongs to (prod,stag,dev). If omitted, all the resource names won't contain any environment information.
- * [`project`]: String(required): the name of the project this state belongs to.
- * [`create_dynamodb_lock_table`]: String(optional): toggle to enable or not the DynamoDB table creation. Set to false to disable. Defaults to true.
- * [`create_s3_bucket`]: String(optional): toggle to enable or not the S3 bucket creation. Set to false to disable. Defaults to true.
- * [`shared_aws_account_ids`]: List(optional): A list of AWS account IDs to share the S3 bucket and DynamoDB table with. Defaults to [].
+### Available variables
 
-### Output:
- * [`bucket_id`]: String: The name of the bucket
- * [`locktable_id`]: String: the id of the DynamoDB lock table.
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| create_dynamodb_lock_table | Create a DynamoDB table for state locking. Set to false or 0 to disable. Defaults to true | string | `true` | no |
+| create_s3_bucket | Create the S3 bucket and policy. Set to false of 0 to disable. Defaults to true | string | `true` | no |
+| project | Project name | string | - | yes |
+| shared_aws_account_ids | A list of AWS account IDs to share the S3 bucket and DynamoDB table with. | list | `<list>` | no |
+
+### Output
+
+| Name | Description |
+|------|-------------|
+| bucket_id | Id (name) of the S3 bucket |
+| locktable_id | Id (name) of the DynamoDB lock table |
 
 ### Example single environment
 
-```
+```tf
 module "s3" {
   source      = "github.com/skyscrapers/terraform-state//s3?ref=1.0.0"
-  environment = "test"
   project     = "some-project"
 }
 ```
@@ -30,7 +36,7 @@ module "s3" {
 
 When using terraform environments, there's only one remote backend configuration, meaning that there can only be one single bucket for all the environments. That also means that this module can only be managed from one single environment, otherwise you'll get conflicts in terraform. In order to do this you'll have to disable this module on all but one environment. For example like this:
 
-```
+```tf
 module "s3" {
   source                     = "github.com/skyscrapers/terraform-state//s3?ref=1.0.0"
   project                    = "some-project"
@@ -38,8 +44,6 @@ module "s3" {
   create_s3_bucket           = "${terraform.env == "production" ? "true" : "false"}"
 }
 ```
-
-Note that you'll also need to drop the `environment` variable, as the bucket will be used for more than one environment.
 
 ### Example using terraform environment on multiple AWS accounts
 
@@ -51,7 +55,7 @@ The DynamoDB lock table is a different story, as it can't be shared with other A
 
 TL;DR There's going to be a single S3 bucket for all the terraform environments (and AWS accounts), but managed from a single environment. And there's going to be a different DynamoDB lock table for each environment (and AWS account).
 
-```
+```tf
 module "s3" {
   source                     = "github.com/skyscrapers/terraform-state//s3?ref=1.0.0"
   project                    = "some-project"

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -80,7 +80,7 @@ EOF
   }
 }
 
-resource "aws_dynamodb_table" "terraform-remote-state-locktable" {
+resource "aws_dynamodb_table" "terraform_state_locktable" {
   count          = "${var.create_dynamodb_lock_table == "true" ? 1 : 0}"
   name           = "terraform-remote-state-lock-${var.project}"
   read_capacity  = 1

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -5,5 +5,5 @@ output "bucket_id" {
 
 output "locktable_id" {
   description = "Id (name) of the DynamoDB lock table"
-  value       = "${join("", aws_dynamodb_table.terraform-state-locktable.*.id)}"
+  value       = "${join("", aws_dynamodb_table.terraform_state_locktable.*.id)}"
 }

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -1,7 +1,9 @@
 output "bucket_id" {
-  value = "${join("", aws_s3_bucket.state.*.id)}"
+  description = "Id (name) of the S3 bucket"
+  value       = "${join("", aws_s3_bucket.state.*.id)}"
 }
 
 output "locktable_id" {
-  value = "${join("", aws_dynamodb_table.terraform-state-locktable.*.id)}"
+  description = "Id (name) of the DynamoDB lock table"
+  value       = "${join("", aws_dynamodb_table.terraform-state-locktable.*.id)}"
 }

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -2,11 +2,6 @@ variable "project" {
   description = "Project name"
 }
 
-variable "environment" {
-  description = "Environment name"
-  default     = ""
-}
-
 variable "create_dynamodb_lock_table" {
   description = "Create a DynamoDB table for state locking. Set to false or 0 to disable. Defaults to true"
   default     = "true"


### PR DESCRIPTION
`environment` variable is no longer needed as there's just one state bucket for all environments. _In any case it could be added together with `project` if really needed._

Renamed s3 bucket and dynamodb table names to make them more clear and to avoid collisions with old buckets.

As per https://github.com/skyscrapers/engineering/issues/147