### PR TITLE
Secure and simplify the s3 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,7 @@ The bucket has an policy where you can only upload files with encryption enabled
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| create\_dynamodb\_lock\_table | Create a DynamoDB table for state locking. Set to false or 0 to disable. Defaults to true | string | `"true"` | no |
-| create\_s3\_bucket | Create the S3 bucket and policy. Set to false of 0 to disable. Defaults to true | string | `"true"` | no |
 | project | Project name | string | n/a | yes |
-| shared\_aws\_account\_ids | A list of AWS account IDs to share the S3 bucket and DynamoDB table with. | list | `<list>` | no |
 
 ### Output
 

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,10 +1,17 @@
 resource "aws_s3_bucket" "state" {
-  count  = "${var.create_s3_bucket == "true" ? 1 : 0}"
   bucket = "terraform-remote-state-${var.project}"
   acl    = "private"
 
   versioning {
     enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 
   tags {
@@ -13,8 +20,15 @@ resource "aws_s3_bucket" "state" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "example" {
+  bucket                  = "${aws_s3_bucket.state.id}"
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_policy" "b" {
-  count  = "${var.create_s3_bucket == "true" ? 1 : 0}"
   bucket = "${aws_s3_bucket.state.bucket}"
 
   policy = <<EOF
@@ -45,43 +59,13 @@ resource "aws_s3_bucket_policy" "b" {
           "s3:x-amz-server-side-encryption": "true"
         }
       }
-    }${length(data.template_file.cross_account_bucket_sharing_policy.*.rendered) == 0 ? format("%s","") : format("%s", join("", data.template_file.cross_account_bucket_sharing_policy.*.rendered))}
+    }
   ]
 }
 EOF
 }
 
-data "template_file" "cross_account_bucket_sharing_policy" {
-  count = "${length(var.shared_aws_account_ids) > 0 && var.create_s3_bucket == "true" ? 1 : 0}"
-
-  template = <<EOF
-,{
-   "Sid": "Shared bucket permissions",
-   "Effect": "Allow",
-   "Principal": {
-      "AWS": [ $${principal_aws} ]
-   },
-   "Action": [
-      "s3:GetBucketLocation",
-      "s3:ListBucket",
-      "s3:GetObject*",
-      "s3:PutObject*"
-   ],
-   "Resource": [
-      "$${bucket_arn}",
-      "$${bucket_arn}/*"
-   ]
-}
-EOF
-
-  vars {
-    principal_aws = "${join(",", formatlist("\"arn:aws:iam::%s:root\"", var.shared_aws_account_ids))}"
-    bucket_arn    = "${aws_s3_bucket.state.arn}"
-  }
-}
-
 resource "aws_dynamodb_table" "terraform_state_locktable" {
-  count          = "${var.create_dynamodb_lock_table == "true" ? 1 : 0}"
   name           = "terraform-remote-state-lock-${var.project}"
   read_capacity  = 1
   write_capacity = 1

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -1,11 +1,11 @@
 output "bucket_id" {
+  value       = "${aws_s3_bucket.state.id}"
   description = "Id (name) of the S3 bucket"
-  value       = "${join("", aws_s3_bucket.state.*.id)}"
 }
 
 output "locktable_id" {
+  value       = "${aws_dynamodb_table.terraform_state_locktable.id}"
   description = "Id (name) of the DynamoDB lock table"
-  value       = "${join("", aws_dynamodb_table.terraform_state_locktable.*.id)}"
 }
 
 output "tf_policy_name" {

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -1,19 +1,3 @@
 variable "project" {
   description = "Project name"
 }
-
-variable "create_dynamodb_lock_table" {
-  description = "Create a DynamoDB table for state locking. Set to false or 0 to disable. Defaults to true"
-  default     = "true"
-}
-
-variable "create_s3_bucket" {
-  description = "Create the S3 bucket and policy. Set to false of 0 to disable. Defaults to true"
-  default     = "true"
-}
-
-variable "shared_aws_account_ids" {
-  description = "A list of AWS account IDs to share the S3 bucket and DynamoDB table with."
-  type        = "list"
-  default     = []
-}


### PR DESCRIPTION
- Enable server-side encryption by default
- Restrict any public access to the bucket
- Remove variables to make the creation of s3 bucket and dynamodb table optional (not needed anymore)
- Remove variable to share the s3 bucket with other accounts (not needed anymore)