### PR TITLE
Allow s3:DeleteObject on tf state bucket

### DIFF
--- a/s3/iam_policy.tf
+++ b/s3/iam_policy.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "tf" {
     actions = [
       "s3:GetObject",
       "s3:PutObject",
+      "s3:DeleteObject",
     ]
 
     resources = ["${aws_s3_bucket.state.arn}/*"]


### PR DESCRIPTION

Otherwise we cannot delete a terraform workspace.
As it is a versioned bucket and the iam policy doesn't give s3:DeleteObjectVersion permissions, all deleted state files will remain in the bucket as old versions.