### PR TITLE
Removing DynamoDB for pure s3 backend

### DIFF
--- a/s3/iam_policy.tf
+++ b/s3/iam_policy.tf
@@ -16,16 +16,6 @@ data "aws_iam_policy_document" "tf" {
 
     resources = ["${aws_s3_bucket.state.arn}/*"]
   }
-
-  statement {
-    actions = [
-      "dynamodb:GetItem",
-      "dynamodb:PutItem",
-      "dynamodb:DeleteItem",
-    ]
-
-    resources = [aws_dynamodb_table.terraform_state_locktable.arn]
-  }
 }
 
 resource "aws_iam_policy" "tf" {

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -66,19 +66,3 @@ EOF
 
   depends_on = [aws_s3_bucket_public_access_block.example]
 }
-
-resource "aws_dynamodb_table" "terraform_state_locktable" {
-  name         = "terraform-remote-state-lock-${var.project}"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "LockID"
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-
-  tags = {
-    Name    = "terraform-remote-state-lock-${var.project}"
-    Project = var.project
-  }
-}

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -3,11 +3,6 @@ output "bucket_id" {
   description = "Id (name) of the S3 bucket"
 }
 
-output "locktable_id" {
-  value       = aws_dynamodb_table.terraform_state_locktable.id
-  description = "Id (name) of the DynamoDB lock table"
-}
-
 output "tf_policy_name" {
   value       = aws_iam_policy.tf.name
   description = "The name of the policy for Terraform users to access the state and lock table"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? Any specific requirements regarding rollout?-->
Removing DynamoDB for pure s3 backend

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/platform/issues/1672

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the PR process as described [here](https://docs.skyscrapers.eu/docs/how-to-guides/coding_guidelines/git/#pull-requests)
- [ ] My code has been tested: 
  - [ ] Locally (please provide details if applicable)  
  - [ ] In this PR using Atlantis 
- [ ] My code is ready to be applied.  
  - [ ] contains breaking changes 

> [!TIP]
> - If you’ve made any changes to the IaC, you can manually trigger Atlantis to test your changes.
> - Changes to the code in the `terraform/live` folder will automatically trigger Atlantis.
> - If you’ve made changes to the code in the `terraform/modules` folder, you can manually trigger Atlantis by commenting on the PR with: 
`atlantis plan -d terraform/live/<environment>/<project>`.
This command will trigger a plan for the specified project within the specified environment.
